### PR TITLE
Add initial CloudTrail module

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2018 Azavea Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -29,8 +29,12 @@ module "cloudtrail" {
 - `create_s3_bucket` - Whether or not to create a new S3 bucket. When `false`,
    you must provide a valid bucket to `s3_bucket_name` (default: `true`)
 - `s3_bucket_name` - Name of the S3 bucket to store logs in (required)
-- `s3_bucket_lifecycle_expiration` - How many days to store logs before they will be
-   deleted (default: `90`)
+- `enable_s3_bucket_expiration` - Specifies whether to enable an expiration policy for the log stora   ge bucket (default: `false`)
+- `s3_bucket_days_to_expiration` - How many days to store logs before they will be
+   deleted. Only applies if `enable_s3_bucket_expiration` is true (default: `90`)
+- `enable_s3_bucket_transition` - Specifies whether to enable a storage class transition for the S3 bucket (default: `true`)
+- `s3_bucket_days_to_transition` - How many days to store logs before they will be transitioned to a  new storage class. Only applies if `enable_s3_bucket_transition` is true (default: `90`)
+- `s3_bucket_transition_storage_class` - Specifies the S3 storage class to which logs will transiti    on for archival. Only applies if `enable_s3_bucket_transition` is true (default: `ONEZONE_IA`)
 - `enable_logging` - Specifies whether to enable logging for the trail (default: `true`)
 - `include_global_service_events` - Specifies whether the trail is publishing events
   from global services such as IAM (default: `true`)
@@ -52,3 +56,6 @@ module "cloudtrail" {
 - `id` - The name of the trail.
 - `home_region` - The region in which the trail was created.
 - `arn` - The Amazon Resource Name of the trail.
+- `bucket_id` - The name of the log bucket, if one was created -- otherwise, an empty string.
+- `bucket_arn` - The Amazon Resource Name of the log bucket, if one was created --
+  otherwise, an empty string."

--- a/README.md
+++ b/README.md
@@ -72,4 +72,4 @@ module "cloudtrail" {
 - `arn` - The Amazon Resource Name of the trail.
 - `bucket_id` - The name of the log bucket, if one was created -- otherwise, an empty string.
 - `bucket_arn` - The Amazon Resource Name of the log bucket, if one was created --
-  otherwise, an empty string."
+  otherwise, an empty string.

--- a/README.md
+++ b/README.md
@@ -12,10 +12,24 @@ automatically.
 module "cloudtrail" {
   source = "github.com/azavea/terraform-aws-cloudtrail?ref=develop"
 
-  region                         = "us-east-1"
-  create_s3_bucket               = true
-  s3_bucket_name                 = "mysite-logs"
-  s3_bucket_lifecycle_expiration = 90
+  region           = "us-east-1"
+  create_s3_bucket = true
+  s3_bucket_name   = "mysite-logs"
+  s3_key_prefix    = "cloudtrail"
+
+  enable_s3_bucket_expiration  = false
+  s3_bucket_days_to_expiration = 90
+
+  enable_s3_bucket_transition        = true
+  s3_bucket_days_to_transition       = 90
+  s3_bucket_transition_storage_class = "ONEZONE_IA"
+
+  enable_logging             = true
+  enable_log_file_validation = false
+
+  include_global_service_events = true
+  is_multi_region_trail         = false
+  is_organization_trail         = false
 
   project     = "My Site"
   environment = "Production"
@@ -29,6 +43,8 @@ module "cloudtrail" {
 - `create_s3_bucket` - Whether or not to create a new S3 bucket. When `false`,
    you must provide a valid bucket to `s3_bucket_name` (default: `true`)
 - `s3_bucket_name` - Name of the S3 bucket to store logs in (required)
+- `s3_key_prefix` - Specifies the S3 key prefix that precedes the name of the bucket
+   you have designated for log file delivery (Optional)
 - `enable_s3_bucket_expiration` - Specifies whether to enable an expiration policy for the log stora   ge bucket (default: `false`)
 - `s3_bucket_days_to_expiration` - How many days to store logs before they will be
    deleted. Only applies if `enable_s3_bucket_expiration` is true (default: `90`)
@@ -44,8 +60,6 @@ module "cloudtrail" {
   is enabled (default: `false`)
 - `is_organization_trail` - Specifies whether the trail is an AWS Organizations trail,
   which must be created in the organization master account (default: `false`)
-- `s3_key_prefix` - Specifies the S3 key prefix that precedes the name of the bucket
-   you have designated for log file delivery (Optional)
 - `project` - Project name, used for tagging and naming the trail (default:
   `Unknown`)
 - `environment` - Name of the environment this trail is targeting (default:

--- a/README.md
+++ b/README.md
@@ -1,0 +1,43 @@
+# terraform-aws-cloudtrail
+
+A Terraform module to create an Amazon Web Services (AWS) CloudTrail trail.
+
+## Usage
+
+This module creates a trail that logs to an S3 bucket. The module can be
+configured to log to an existing S3 bucket, or to make a new one for you
+automatically.
+
+```hcl
+module "cloudtrail" {
+  source = "github.com/azavea/terraform-aws-cloudtrail?ref=develop"
+
+  region                         = "us-east-1"
+  create_s3_bucket               = true
+  s3_bucket_name                 = "mysite-logs"
+  s3_bucket_lifecycle_expiration = 90
+
+  project     = "My Site"
+  environment = "Production"
+}
+```
+
+## Variables
+
+- `region` - Name of the region where the trail should be created (default:
+  `us-east-1`)
+- `create_s3_bucket` - Whether or not to create a new S3 bucket. When `false`,
+   you must provide a valid bucket to `s3_bucket_name` (default: `true`)
+- `s3_bucket_name` - Name of the S3 bucket to store logs in (required)
+- `s3_bucket_lifecycle_expiration` - How many days to store logs before they will be
+   deleted (default: `90`)
+- `project` - Project name, used for tagging and naming the trail (default:
+  `Unknown`)
+- `environment` - Name of the environment this trail is targeting (default:
+  `Unkown`)
+
+## Outputs
+
+- `id` - The name of the trail.
+- `home_region` - The region in which the trail was created.
+- `arn` - The Amazon Resource Name of the trail.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,17 @@ module "cloudtrail" {
 - `s3_bucket_name` - Name of the S3 bucket to store logs in (required)
 - `s3_bucket_lifecycle_expiration` - How many days to store logs before they will be
    deleted (default: `90`)
+- `enable_logging` - Specifies whether to enable logging for the trail (default: `true`)
+- `include_global_service_events` - Specifies whether the trail is publishing events
+  from global services such as IAM (default: `true`)
+- `is_multi_region_trail` - Specifies whether the trail is created in the current region or
+  in all regions (default: `false`)
+- `enable_log_file_validation` - Specifies whether log file integrity validation
+  is enabled (default: `false`)
+- `is_organization_trail` - Specifies whether the trail is an AWS Organizations trail,
+  which must be created in the organization master account (default: `false`)
+- `s3_key_prefix` - Specifies the S3 key prefix that precedes the name of the bucket
+   you have designated for log file delivery (Optional)
 - `project` - Project name, used for tagging and naming the trail (default:
   `Unknown`)
 - `environment` - Name of the environment this trail is targeting (default:

--- a/main.tf
+++ b/main.tf
@@ -24,10 +24,19 @@ resource "aws_s3_bucket" "trail" {
   region = "${var.region}"
 
   lifecycle_rule {
-    enabled = true
+    enabled = "${var.enable_s3_bucket_transition}"
+
+    transition {
+      days          = "${var.s3_bucket_days_to_transition}"
+      storage_class = "${var.s3_bucket_transition_storage_class}"
+    }
+  }
+
+  lifecycle_rule {
+    enabled = "${var.enable_s3_bucket_expiration}"
 
     expiration {
-      days = "${var.s3_bucket_lifecycle_expiration}"
+      days = "${var.s3_bucket_days_to_expiration}"
     }
   }
 }
@@ -61,7 +70,7 @@ data "aws_iam_policy_document" "cloudtrail_log_access" {
     sid     = "AWSCloudTrailWrite"
     actions = ["s3:PutObject"]
 
-    resources = ["${var.s3_key_prefix != "" ? ${aws_s3_bucket.trail.arn}/${var.s3_key_prefix}/* : ${aws_s3_bucket.trail.arn}/*}"]
+    resources = ["${var.s3_key_prefix != "" ? format("%s/%s/*", aws_s3_bucket.trail.arn, var.s3_key_prefix) : format("%s/*", aws_s3_bucket.trail.arn)}"]
 
     principals {
       type        = "Service"

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,74 @@
+resource "aws_cloudtrail" "trail" {
+  name           = "ctl${tile(var.project)}${title(var.environment)}"
+  s3_bucket_name = "${var.s3_bucket_name}"
+
+  enable_logging                = true
+  include_global_service_events = true
+  is_multi_region_trail         = false
+  enable_log_file_validation    = false
+
+  tags {
+    Name        = "${var.project}"
+    Environment = "${var.environment}"
+  }
+}
+
+resource "aws_s3_bucket" "trail" {
+  count = "${var.create_s3_bucket ? 1 : 0}"
+
+  bucket = "${var.s3_bucket_name}"
+  region = "${var.region}"
+
+  lifecycle_rule {
+    enabled = true
+
+    expiration {
+      days = "${var.s3_bucket_lifecycle_expiration}"
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "trail" {
+  count = "${var.create_s3_bucket ? 1 : 0}"
+
+  bucket = "${aws_s3_bucket.trail.id}"
+  policy = "${data.aws_iam_policy_document.cloudtrail_log_access.json}"
+}
+
+#
+# Access policy for CloudTrail <> S3
+# See: https://docs.aws.amazon.com/awscloudtrail/latest/userguide/create-s3-bucket-policy-for-cloudtrail.html
+#
+data "aws_iam_policy_document" "cloudtrail_log_access" {
+  statement {
+    sid       = "AWSCloudTrailAclCheck"
+    actions   = ["s3:GetBucketAcl"]
+    resources = ["${aws_s3_bucket.trail.arn}"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["cloudtrail.amazonaws.com"]
+    }
+  }
+
+  statement {
+    sid     = "AWSCloudTrailWrite"
+    actions = ["s3:PutObject"]
+
+    # The AWS example policy has a more detailed path. We don't necessarily know
+    # what will be in the bucket, so just apply the rule to all subdirectories
+    # of the bucket..
+    resources = ["${aws_s3_bucket.trail.arn}/*"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["cloudtrail.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "s3:x-amz-acl"
+      value    = "bucket-owner-full-control"
+    }
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,14 @@
+output "id" {
+  value       = "${aws_cloudtrail.trail.id}"
+  description = "The name of the trail."
+}
+
+output "home_region" {
+  value       = "${aws_cloudtrail.trail.home_region}"
+  description = "The region in which the trail was created."
+}
+
+output "arn" {
+  value       = "${aws_cloudtrail.trail.arn}"
+  description = "The Amazon Resource Name of the trail."
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -12,3 +12,13 @@ output "arn" {
   value       = "${aws_cloudtrail.trail.arn}"
   description = "The Amazon Resource Name of the trail."
 }
+
+output "bucket_id" {
+  value       = "${element(concat(aws_s3_bucket.trail.*.id, list("")), 0)}"
+  description = "The name of the log bucket, if one was created -- otherwise, an empty string."
+}
+
+output "bucket_arn" {
+  value       = "${element(concat(aws_s3_bucket.trail.*.arn, list("")), 0)}"
+  description = "The Amazon Resource Name of the log bucket, if one was created -- otherwise, an empty string."
+}

--- a/variables.tf
+++ b/variables.tf
@@ -22,9 +22,29 @@ variable "s3_bucket_name" {
   description = "Name of the S3 bucket to store logs in (required)."
 }
 
-variable "s3_bucket_lifecycle_expiration" {
+variable "enable_s3_bucket_expiration" {
+  default     = "false"
+  description = "Specifies whether to enable an expiration policy for the log storage bucket."
+}
+
+variable "s3_bucket_days_to_expiration" {
   default     = "90"
-  description = "How many days to store logs before they will be deleted."
+  description = "How many days to store logs before they will be deleted. Only applies if `enable_s3_bucket_expiration` is true."
+}
+
+variable "enable_s3_bucket_transition" {
+  default     = "true"
+  description = "Specifies whether to enable a storage class transition for the S3 bucket."
+}
+
+variable "s3_bucket_days_to_transition" {
+  default     = "90"
+  description = "How many days to store logs before they will be transitioned to a new storage class. Only applies if `enable_s3_bucket_transition` is true."
+}
+
+variable "s3_bucket_transition_storage_class" {
+  default     = "ONEZONE_IA"
+  description = "Specifies the S3 storage class to which logs will transition for archival. Only applies if `enable_s3_bucket_transition` is true."
 }
 
 variable "enable_logging" {

--- a/variables.tf
+++ b/variables.tf
@@ -15,7 +15,7 @@ variable "region" {
 
 variable "create_s3_bucket" {
   default     = "true"
-  description = "Whether or not to create a new S3 bucket. When false, you must provide a valid bucket to 's3_bucket_name'."
+  description = "Specifies whether to create a new S3 bucket. When false, you must provide a valid bucket to 's3_bucket_name'."
 }
 
 variable "s3_bucket_name" {
@@ -25,4 +25,34 @@ variable "s3_bucket_name" {
 variable "s3_bucket_lifecycle_expiration" {
   default     = "90"
   description = "How many days to store logs before they will be deleted."
+}
+
+variable "enable_logging" {
+  default     = "true"
+  description = "Specifies whether to enable logging for the trail."
+}
+
+variable "include_global_service_events" {
+  default     = "true"
+  description = "Specifies whether the trail is publishing events from global services such as IAM."
+}
+
+variable "is_multi_region_trail" {
+  default     = "false"
+  description = "Specifies whether the trail is created in the current region or in all regions."
+}
+
+variable "enable_log_file_validation" {
+  default     = "false"
+  description = "Specifies whether log file integrity validation is enabled."
+}
+
+variable "is_organization_trail" {
+  default     = "false"
+  description = "Specifies whether the trail is an AWS Organizations trail, which must be created in the organization master account."
+}
+
+variable "s3_key_prefix" {
+  default     = ""
+  description = "Specifies the S3 key prefix that precedes the name of the bucket you have designated for log file delivery."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,28 @@
+variable "project" {
+  default     = "Unknown"
+  description = "Project name, used for tagging and naming the Trail."
+}
+
+variable "environment" {
+  default     = "Unknown"
+  description = "Name of the environment this Trail is targeting."
+}
+
+variable "region" {
+  default     = "us-east-1"
+  description = "Name of the region where the Trail should be created."
+}
+
+variable "create_s3_bucket" {
+  default     = "true"
+  description = "Whether or not to create a new S3 bucket. When false, you must provide a valid bucket to 's3_bucket_name'."
+}
+
+variable "s3_bucket_name" {
+  description = "Name of the S3 bucket to store logs in (required)."
+}
+
+variable "s3_bucket_lifecycle_expiration" {
+  default     = "90"
+  description = "How many days to store logs before they will be deleted."
+}


### PR DESCRIPTION
# Overview

Use Terraform to define all of the AWS resources necessary to support a basic CloudTrail setup. This includes:

- CloudTrail trail
- S3 bucket for logs (optional -- can also be passed a pre-configured bucket)
- S3 bucket policy allowing access to CloudTrail

Closes https://github.com/azavea/operations/issues/138.

## Notes

- I used my best judgement for what a simple setup should look like, since I couldn't find an example of a CloudTrail setup in an existing Azavea repo. Feel free to drop pointers to good examples, or to suggest different high-level designs.

## Testing

### 1. Test creating resources with an automatically generated log bucket

1. Create a new directory for testing the module: `mkdir test-module && cd test-module`
2. Write a `main.tf` file that inherits from this module:

```hcl
module "cloudtrail" {
  source = "github.com/azavea/terraform-aws-cloudtrail?ref=feature%2Fjean%2Finitial-setup"

  region                         = "us-east-1"
  create_s3_bucket               = true
  s3_bucket_name                 = "testing-terraform-aws-cloudtrail"
  s3_bucket_lifecycle_expiration = 90

  project     = "My Site"
  environment = "Production"
}

provider "aws" {
  region  = "us-east-1"
  version = "~> 1.52.0"
}

output "bucket_id" {
  value = "${module.cloudtrail.bucket_id}"
}

output "bucket_arn" {
  value = "${module.cloudtrail.bucket_arn}"
}
``` 

3. Initialize the test directory with `terraform init`
4. Create a plan with `terraform plan -out terraform.tfplan` and confirm that it looks reasonable
5. Create resources with `terraform apply terraform.tfplan`
6. Confirm all resources look good
7. Delete the S3 bucket in the console
8. Remove the S3 bucket from Terraform state with `terraform state rm module.cloudtrail.aws_s3_bucket.trail`
9.  Clean up the rest of the Terraform-managed resources with `terraform destroy`

### 2. Test creating a trail with an existing log bucket

1. Create a bucket called `testing-terraform-aws-cloudtrail` in S3
2. Attach a bucket policy to [allow CloudWatch to write logs to the bucket](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/create-s3-bucket-policy-for-cloudtrail.html) (Terraform will complain that the permissions are incorrect if you don't):

```json
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Sid": "AWSCloudTrailAclCheck",
            "Effect": "Allow",
            "Principal": {"Service": "cloudtrail.amazonaws.com"},
            "Action": "s3:GetBucketAcl",
            "Resource": "arn:aws:s3:::testing-terraform-aws-cloudtrail"
        },
        {
            "Sid": "AWSCloudTrailWrite",
            "Effect": "Allow",
            "Principal": {"Service": "cloudtrail.amazonaws.com"},
            "Action": "s3:PutObject",
            "Resource": "arn:aws:s3:::testing-terraform-aws-cloudtrail/*",
            "Condition": {"StringEquals": {"s3:x-amz-acl": "bucket-owner-full-control"}}
        }
    ]
}
```

3. Set `create_s3_bucket` to `false` in `main.tf`
4. Create a plan with `terraform plan -out terraform.tfplan` and confirm that it looks reasonable
5. Create resources with `terraform apply terraform.tfplan`
6. Confirm all resources look good
7. Delete the S3 bucket in the console
8. Remove the S3 bucket from Terraform state with `terraform state rm module.cloudtrail.aws_s3_bucket.trail`
9.  Clean up the rest of the Terraform-managed resources with `terraform destroy`